### PR TITLE
Make the quarkus starter work again with quarkus 3.x.x

### DIFF
--- a/project/kediatr-quarkus-starter/build.gradle.kts
+++ b/project/kediatr-quarkus-starter/build.gradle.kts
@@ -4,9 +4,9 @@ plugins {
 
 dependencies {
     api(project(":project:kediatr-core"))
-    implementation(platform("io.quarkus:quarkus-bom:2.16.7.Final"))
+    implementation(platform("io.quarkus:quarkus-bom:3.0.2.Final"))
     implementation("io.quarkus:quarkus-arc")
-    implementation("javax.enterprise:cdi-api:2.0")
+    implementation("jakarta.enterprise:jakarta.enterprise.cdi-api:4.0.1")
 }
 
 dependencies {

--- a/project/kediatr-quarkus-starter/src/main/kotlin/com/trendyol/kediatr/quarkus/KediatRBeanProvider.kt
+++ b/project/kediatr-quarkus-starter/src/main/kotlin/com/trendyol/kediatr/quarkus/KediatRBeanProvider.kt
@@ -6,10 +6,11 @@ import com.trendyol.kediatr.DependencyProvider
 import com.trendyol.kediatr.Mediator
 import com.trendyol.kediatr.MediatorBuilder
 import io.quarkus.runtime.Startup
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.enterprise.inject.spi.Bean
+import jakarta.enterprise.inject.spi.BeanManager
 import java.util.concurrent.ConcurrentHashMap
-import javax.enterprise.context.ApplicationScoped
-import javax.enterprise.inject.spi.Bean
-import javax.enterprise.inject.spi.BeanManager
+
 
 class KediatRBeanProvider(
     private val beanManager: BeanManager,

--- a/project/kediatr-quarkus-starter/src/test/kotlin/com/trendyol/kediatr/quarkus/CommandHandlerTests.kt
+++ b/project/kediatr-quarkus-starter/src/test/kotlin/com/trendyol/kediatr/quarkus/CommandHandlerTests.kt
@@ -6,8 +6,8 @@ import com.trendyol.kediatr.HandlerNotFoundException
 import com.trendyol.kediatr.Mediator
 import io.quarkus.runtime.Startup
 import io.quarkus.test.junit.QuarkusTest
-import javax.enterprise.context.ApplicationScoped
-import javax.inject.Inject
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.inject.Inject
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Test

--- a/project/kediatr-quarkus-starter/src/test/kotlin/com/trendyol/kediatr/quarkus/CommandWithResultHandlerTest.kt
+++ b/project/kediatr-quarkus-starter/src/test/kotlin/com/trendyol/kediatr/quarkus/CommandWithResultHandlerTest.kt
@@ -1,14 +1,20 @@
 package com.trendyol.kediatr.quarkus
 
-import com.trendyol.kediatr.*
+import com.trendyol.kediatr.CommandWithResult
+import com.trendyol.kediatr.CommandWithResultHandler
+import com.trendyol.kediatr.HandlerNotFoundException
+import com.trendyol.kediatr.Mediator
 import io.quarkus.runtime.Startup
 import io.quarkus.test.junit.QuarkusTest
-import javax.enterprise.context.ApplicationScoped
-import javax.inject.Inject
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.inject.Inject
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Test
-import kotlin.test.*
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 private var testCounter = 0
 private var asyncTestCounter = 0

--- a/project/kediatr-quarkus-starter/src/test/kotlin/com/trendyol/kediatr/quarkus/NotificationHandlerTest.kt
+++ b/project/kediatr-quarkus-starter/src/test/kotlin/com/trendyol/kediatr/quarkus/NotificationHandlerTest.kt
@@ -1,15 +1,15 @@
 package com.trendyol.kediatr.quarkus
 
-import com.trendyol.kediatr.NotificationHandler
 import com.trendyol.kediatr.Mediator
 import com.trendyol.kediatr.Notification
+import com.trendyol.kediatr.NotificationHandler
 import io.quarkus.runtime.Startup
 import io.quarkus.test.junit.QuarkusTest
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.inject.Inject
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Test
-import javax.enterprise.context.ApplicationScoped
-import javax.inject.Inject
 import kotlin.test.assertTrue
 
 private var notificationTestCounter = 0

--- a/project/kediatr-quarkus-starter/src/test/kotlin/com/trendyol/kediatr/quarkus/PipelineBehaviorTest.kt
+++ b/project/kediatr-quarkus-starter/src/test/kotlin/com/trendyol/kediatr/quarkus/PipelineBehaviorTest.kt
@@ -7,8 +7,8 @@ import com.trendyol.kediatr.PipelineBehavior
 import com.trendyol.kediatr.RequestHandlerDelegate
 import io.quarkus.runtime.Startup
 import io.quarkus.test.junit.QuarkusTest
-import javax.enterprise.context.ApplicationScoped
-import javax.inject.Inject
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.inject.Inject
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Test

--- a/project/kediatr-quarkus-starter/src/test/kotlin/com/trendyol/kediatr/quarkus/QueryHandlerTest.kt
+++ b/project/kediatr-quarkus-starter/src/test/kotlin/com/trendyol/kediatr/quarkus/QueryHandlerTest.kt
@@ -6,8 +6,8 @@ import com.trendyol.kediatr.Query
 import com.trendyol.kediatr.QueryHandler
 import io.quarkus.runtime.Startup
 import io.quarkus.test.junit.QuarkusTest
-import javax.enterprise.context.ApplicationScoped
-import javax.inject.Inject
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.inject.Inject
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals


### PR DESCRIPTION
Since quarkus 3.0.0 javax. packages were renamed to the jakarta. packages.

This aligns all imports so the quarkus starter works again :)